### PR TITLE
Fix for issue with Apple iTunes Podcasts addon

### DIFF
--- a/lib/xbmcswift2/plugin.py
+++ b/lib/xbmcswift2/plugin.py
@@ -215,7 +215,7 @@ class Plugin(XBMCMixin):
         # well
         if url is None:
             url = sys.argv[0]
-            if len(sys.argv) == 3:
+            if len(sys.argv) >= 3:
                 url += sys.argv[2]
         if handle is None:
             handle = sys.argv[1]


### PR DESCRIPTION
This fixes browsing for podcasts in the 'Apple iTunes Podcasts' addon.
(https://kodi.wiki/view/Add-on:Apple_iTunes_Podcasts)
Browsing the list of podcasts stayed stuck on the choice between Audio podcasts and Video podcasts.