### PR TITLE
Add minor fix for python3 compatibility

### DIFF
--- a/lib/xbmcswift2/plugin.py
+++ b/lib/xbmcswift2/plugin.py
@@ -293,7 +293,10 @@ class Plugin(XBMCMixin):
             rule = self._view_functions[endpoint]
         except KeyError:
             try:
-                rule = (rule for rule in self._view_functions.values() if rule.view_func == endpoint).next()
+                if PY3:
+                    rule = (rule for rule in self._view_functions.values() if rule.view_func == endpoint).__next__()
+                else:
+                    rule = (rule for rule in self._view_functions.values() if rule.view_func == endpoint).next()
             except StopIteration:
                 raise NotFoundException(
                     '%s doesn\'t match any known patterns.' % endpoint)


### PR DESCRIPTION
Minor py3 incompatibility that broke [primaeval/plugin.program.simple.favourites](https://github.com/primaeval/plugin.program.simple.favourites) on my LibreELEC box.

Glad to see that abandoned addons are being adopted by Team KODI. Life on the py3 bleeding edge has been enough of an annoyance lately that I'm beginning to look into fixing addons I rely on myself.